### PR TITLE
Configurable file sized in download test

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,28 +87,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   recursive_regex:
     dependency: transitive
     description:
@@ -134,14 +127,14 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   speed_test_dart:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.4"
   stack_trace:
     dependency: transitive
     description:
@@ -162,7 +155,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   sync:
     dependency: transitive
     description:
@@ -176,14 +169,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,3 +1,5 @@
+import 'package:speed_test_dart/enums/file_size.dart';
+
 const configUrl = 'https://www.speedtest.net/speedtest-config.php';
 
 const serversUrls = [
@@ -7,6 +9,11 @@ const serversUrls = [
   'https://c.speedtest.net/speedtest-servers.php'
 ];
 
-const downloadSizes = [350, 750, 1500, 3000];
+const defaultDownloadSizes = [
+  FileSize.SIZE_350,
+  FileSize.SIZE_750,
+  FileSize.SIZE_1500,
+  FileSize.SIZE_3000,
+];
 const hars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const maxUploadSize = 4; // 400 KB

--- a/lib/enums/file_size.dart
+++ b/lib/enums/file_size.dart
@@ -1,0 +1,25 @@
+const Map<FileSize, int> FILE_SIZE_MAPPING = {
+  FileSize.SIZE_350: 350,
+  FileSize.SIZE_500: 500,
+  FileSize.SIZE_750: 750,
+  FileSize.SIZE_1000: 1000,
+  FileSize.SIZE_1500: 1500,
+  FileSize.SIZE_2000: 2000,
+  FileSize.SIZE_2500: 2500,
+  FileSize.SIZE_3000: 3000,
+  FileSize.SIZE_3500: 3500,
+  FileSize.SIZE_4500: 4500,
+};
+
+enum FileSize {
+  SIZE_350,
+  SIZE_500,
+  SIZE_750,
+  SIZE_1000,
+  SIZE_1500,
+  SIZE_2000,
+  SIZE_2500,
+  SIZE_3000,
+  SIZE_3500,
+  SIZE_4500,
+}

--- a/lib/speed_test_dart.dart
+++ b/lib/speed_test_dart.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 import 'package:http/http.dart' as http;
 import 'package:speed_test_dart/classes/classes.dart';
 import 'package:speed_test_dart/constants.dart';
+import 'package:speed_test_dart/enums/file_size.dart';
 import 'package:sync/sync.dart';
 import 'package:xml_parser/xml_parser.dart';
 
@@ -95,7 +96,11 @@ class SpeedTestDart {
   }
 
   /// Returns urls for download test.
-  List<String> generateDownloadUrls(Server server, int retryCount) {
+  List<String> generateDownloadUrls(
+    Server server,
+    int retryCount,
+    List<FileSize> downloadSizes,
+  ) {
     final downloadUriBase = createTestUrl(server, 'random{0}x{0}.jpg?r={1}');
     final result = <String>[];
     for (final ds in downloadSizes) {
@@ -103,12 +108,11 @@ class SpeedTestDart {
         result.add(
           downloadUriBase
               .toString()
-              .replaceAll('%7B0%7D', ds.toString())
+              .replaceAll('%7B0%7D', FILE_SIZE_MAPPING[ds].toString())
               .replaceAll('%7B1%7D', i.toString()),
         );
       }
     }
-
     return result;
   }
 
@@ -117,12 +121,13 @@ class SpeedTestDart {
     required List<Server> servers,
     int simultaneousDownloads = 2,
     int retryCount = 3,
+    List<FileSize> downloadSizes = defaultDownloadSizes,
   }) async {
     double downloadSpeed = 0;
 
     // Iterates over all servers, if one request fails, the next one is tried.
     for (final s in servers) {
-      final testData = generateDownloadUrls(s, retryCount);
+      final testData = generateDownloadUrls(s, retryCount, downloadSizes);
       final semaphore = Semaphore(simultaneousDownloads);
       final tasks = <int>[];
       final stopwatch = Stopwatch()..start();


### PR DESCRIPTION
This PR mades configurable the size of the files to be downloaded during a download speed test. Although a default recommended size of files is provided, this allows to control the amount of data to be used in each test, so developers can avoid big mobile data consumptions. 
Because only some file sizes are supported by speed test servers, the size was specified using an enum field.